### PR TITLE
calendar should also show due-dates of waiting tasks

### DIFF
--- a/src/commands/CmdCalendar.cpp
+++ b/src/commands/CmdCalendar.cpp
@@ -175,7 +175,7 @@ int CmdCalendar::execute (std::string& output)
     std::vector <Task>::iterator task;
     for (task = tasks.begin (); task != tasks.end (); ++task)
     {
-      if (task->getStatus () == Task::pending)
+      if (task->getStatus () == Task::pending || task->getStatus () == Task::waiting)
       {
         if (task->has ("due") &&
             !task->hasTag ("nocal"))
@@ -558,7 +558,7 @@ std::string CmdCalendar::renderMonths (
           std::vector <Task>::iterator task;
           for (task = all.begin (); task != all.end (); ++task)
           {
-            if (task->getStatus () == Task::pending &&
+            if ((task->getStatus () == Task::pending || task->getStatus () == Task::waiting) &&
                 !task->hasTag ("nocal")             &&
                 task->has ("due"))
             {


### PR DESCRIPTION
To me at least, it doesn't make much sense to hide the due dates in the calendar. Looking at a date in the calendar should inform me about what's going to happen on that day. 